### PR TITLE
Add support for function name overrides in the ML docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# ignore (almost) everything
+*
+# don't ignore the following
+!.npmignore
+!gulpfile.js
+!package-lock.json
+!package.json
+!qconsole
+!tsconfig.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:8.17-buster
+WORKDIR /usr/src/app
+RUN mkdir xml && mkdir ts
+COPY . .
+RUN npm install gulp && npm install
+ENTRYPOINT ["/usr/src/app/node_modules/.bin/gulp"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ So, for example, your ```tsconfig.json``` file might look like:
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "es5"
     },
     "files": [
         "./lib/myCode.ts",
@@ -44,19 +44,26 @@ Make sure to use TypeScript 2.9.2+, to support the Iterable interface used by th
 
 ## Building the TypeScript definitions
 
-The git repository (and npm package) contains the built definitions. If you'd like to re-build them, perform the following:
+The npm package contains the built definitions. If you'd like to re-build them, you can either use a local instance of node, or use docker. Both techniques require MarkLogic Server.
 
+To build the definitions with a local installation of node, perform the following:
 - Clone this project
-- Remove the folder xml/
 - Download a copy of the documentation from here: http://docs.marklogic.com/MarkLogic_9_pubs.zip
 - Extract the zip, and move the folder pubs/raw/apidoc/ into the root of this project, and rename it to xml/
 - Run `npm install`
 - Run `gulp` (may take a minute)
 
-Note: you likely want to override ml-host, ml-user, and such. It runs by default as if you typed:
+To build the definitions with docker, perform the following:
+- Clone this project
+- Download a copy of the documentation from here: http://docs.marklogic.com/MarkLogic_9_pubs.zip
+- Extract the zip to the root of this project
+- Build the image (eg `docker image build -t mltsd .`)
+- Run the container (eg `docker container run --rm --mount type=bind,source=$(pwd)/MarkLogic_9_pubs/pubs/raw/apidoc,target=/usr/src/app/xml,readonly --mount type=bind,source=$(pwd)/ts,target=/usr/src/app/ts mltsd`)
+
+Note: Default values are used for MarkLogic host, port, username, and password. They can be overridden (for either a local node installation, or docker) by using flags. It runs by default as if you typed:
 
 ```
-gulp --ml-host=localhost --ml-port=8000 --ml-user=admin --ml-pass=admin
+--ml-host=localhost --ml-port=8000 --ml-user=admin --ml-pass=admin
 ```
 
 **Warning: The apidocs are fully man-made, so can contain all kinds of typos that can throw off this tool. The processing is fairly delicate. Please report any issue resulting from mistakes in the apidoc, so that we can get them fixed.**

--- a/qconsole/generate-definitions.xqy
+++ b/qconsole/generate-definitions.xqy
@@ -36,23 +36,18 @@ let $definition := xdmp:xslt-eval(
       in RunDMC in api:javascript-name
       (https://github.com/marklogic-community/RunDMC/blob/master/src/apidoc/model/data-access.xqy#L407).
       -->
-      <xsl:variable name="function-name">
-        <xsl:value-of>
-          <xsl:variable name="name-override" select="apidoc:name[@class eq 'javascript']/text()"/>
-          <xsl:choose>
-            <xsl:when test="exists($name-override)">
-              <!-- an override exists, use it -->
-              <xsl:value-of select="$name-override"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <!-- no override exists, follow convention in local:fixName -->
-              <xsl:value-of select="local:fixName(@name)"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:value-of>
-      </xsl:variable>
+      <xsl:variable name="name-override" select="apidoc:name[@class eq 'javascript']/text()"/>
+      <xsl:choose>
+        <xsl:when test="exists($name-override)">
+          <!-- an override exists, use it -->
+          <xsl:value-of select="$name-override"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- no override exists, follow convention in local:fixName -->
+          <xsl:value-of select="local:fixName(@name)"/>
+        </xsl:otherwise>
+      </xsl:choose>
 
-      <xsl:value-of select="$function-name"/>
       <xsl:text>(</xsl:text>
       <xsl:for-each select="apidoc:params/apidoc:param">
         <xsl:variable name="is-multi" select="matches(@type, ',\.\.\.$')"/>

--- a/qconsole/generate-definitions.xqy
+++ b/qconsole/generate-definitions.xqy
@@ -29,7 +29,30 @@ let $definition := xdmp:xslt-eval(
       <xsl:if test="$use-function-keyword">
         <xsl:text>function </xsl:text>
       </xsl:if>
-      <xsl:value-of select="local:fixName(@name)"/>
+
+      <!--
+      The function name can usually be derived by convetion. But in some cases (well, one case - toJSON), an override
+      is provided in the documentation. In those cases, the override should be used. This is also how this is handled
+      in RunDMC in api:javascript-name
+      (https://github.com/marklogic-community/RunDMC/blob/master/src/apidoc/model/data-access.xqy#L407).
+      -->
+      <xsl:variable name="function-name">
+        <xsl:value-of>
+          <xsl:variable name="name-override" select="apidoc:name[@class eq 'javascript']/text()"/>
+          <xsl:choose>
+            <xsl:when test="exists($name-override)">
+              <!-- an override exists, use it -->
+              <xsl:value-of select="$name-override"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <!-- no override exists, follow convention in local:fixName -->
+              <xsl:value-of select="local:fixName(@name)"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:value-of>
+      </xsl:variable>
+
+      <xsl:value-of select="$function-name"/>
       <xsl:text>(</xsl:text>
       <xsl:for-each select="apidoc:params/apidoc:param">
         <xsl:variable name="is-multi" select="matches(@type, ',\.\.\.$')"/>


### PR DESCRIPTION
This fixes the function name of toJSON (was toJson).  See comment in the diff for more details.