### PR TITLE
migrated from gulp-tsc to gulp-typescript

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var argv = require('yargs').argv;
 var fs = require('fs');
 var request = require('request');
 var through = require('through2');
-var typescript = require('gulp-tsc');
+var typescript = require('gulp-typescript');
 var concat = require('gulp-concat');
 var File = require('vinyl');
 
@@ -128,7 +128,7 @@ function generate(){
 
 function validate(){
   return gulp.src(['ts/**/*.ts'])
-  .pipe(typescript({emitError: false}));
+  .pipe(typescript({noEmitOnError: false}));
 };
 
 // Default Task

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "marklogic"
   ],
   "devDependencies": {
-    "gulp": "^4.0.0",
+    "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",
-    "gulp-tsc": "^1.3.2",
+    "gulp-typescript": "^5.0.0",
     "request": "^2.87.0",
     "through2": "^2.0.3",
     "typescript": "^2.9.2",


### PR DESCRIPTION
In gulp-tsc, the `emitError` option was used.  This resulted in a little less error info at the terminal, and a return code of 0 (instead of 1).  gulp-typescript has a similarly named option `noEmitOnError`, but it is NOT the same as gulp-tsc `emitError`.  Toggling `noEmitOnError` changes the terminal output for 1 line about typescript emit.  It also has no impact on the return code (always 1).  Plenty of people are interested in the return code because they use a watcher, and they don't want it to stop on errors.  They tend to have several recommendations, but it seems that the most preferred is [gulp-plumber](https://www.npmjs.com/package/gulp-plumber).  If we're interested in that functionality, I can take a look at that.  In the meantime, let me know if this change is OK.